### PR TITLE
V4: Todos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @Thumuss

--- a/TODO.md
+++ b/TODO.md
@@ -64,3 +64,23 @@ This update will introduce documentations, a better handling error system, JSON 
   - [ ] Update, (using semver) → \w listing dependencies
   - [ ] Clean?
 
+
+## V4 (2024.03.10)
+
+As this date, a new version of typst as been release (v0.11.0-rc1 (fe94bd85)) with a new system of template.
+For now on, this version of `utpm` will focuse on adapting the new system and be compatible with the previous system.
+
+If time isn't running out, I'll add quality of life improvement such as a `Context` system, new commands to go along with the `typst init` command and Dockerise everything (kubernetes included).
+
+The main focus will be : 
+- [ ] Add templates in `utpm`
+- [ ] Compatibility with older version of typst
+- [ ] Fix current bugs
+
+If we got time, I'll add theses things:
+- [ ] Docker, Compose and Kubernetes files (and examples)
+- [ ] `Context`, it will change the actual structure of handling json and errors.
+- [ ] ENV compatible.
+- [ ] get along with `typst init`
+
+If you have any ideas to improve `utpm`, i'll take it <3


### PR DESCRIPTION

## V4 (2024.03.10)

As this date, a new version of typst as been release (`v0.11.0-rc1 (fe94bd85)`) with a new system of template.
For now on, this version of `utpm` will focuse on adapting the new system and be compatible with the previous system.

If time isn't running out, I'll add quality of life improvement such as a `Context` system, new commands to go along with the `typst init` command and Dockerise everything (kubernetes included).

The main focus will be : 
- [ ] Add templates in `utpm`
- [ ] Compatibility with older version of typst
- [ ] Fix current bugs

If we got time, I'll add theses things:
- [ ] Docker, Compose and Kubernetes files (and examples)
- [ ] `Context`, it will change the actual structure of handling json and errors.
- [ ] ENV compatible.
- [ ] get along with `typst init`

If you have any ideas to improve `utpm`, i'll take it <3