### PR TITLE
Add: nix package

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 .vscode
+
+#nix
+.direnv
+result

--- a/README.md
+++ b/README.md
@@ -39,11 +39,63 @@
 <div id="install">
 
 ## ⚡Install
+### With cargo
 Requires Cargo and Rust. 
 
 ```bash
 $ cargo install --git https://github.com/Thumuss/utpm
 ```
+
+<details>
+<summary>
+  
+### With nix
+
+</summary>
+
+#### Nix with flakes enabled :
+
+Get utpm for a bash session without installing it :
+
+```bash
+$ nix shell github:Thumuss/utpm
+```
+
+Or if you use NixOS or home-manager with a flake, install it permanently in your `flake.nix` or your modules :
+
+```nix
+{
+  inputs.utpm.url = "github:Thumuss/utpm";
+  # ...
+
+  outputs = { self, nixpkgs, ... }@inputs: {
+    # change `yourhostname` or `yourusername` to your actual hostname or username
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem { #or homeConfigurations.yourusername
+      system = "x86_64-linux";
+      modules = [
+        # ...
+        {
+          environment.systemPackages = [ inputs.utpm.packages.${system}.default ]; #or home.packages
+        }
+      ];
+    };
+  };
+}
+```
+
+#### Nix without flakes :
+
+Clone the repo and then nix-build into the utpm directory :
+
+```bash
+git clone https://github.com/Thumuss/utpm.git
+cd utpm
+nix-build
+./result/bin/utpm
+```
+Utpm will be at ./result/bin/utpm
+
+</details>
 <div/>
 
 <div id="usage">

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      nodeName = lock.nodes.root.inputs.flake-compat;
+    in
+    fetchTarball {
+      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1734541973,
+        "narHash": "sha256-1wIgLmhvtfxbJVnhFHUYhPqL3gpLn5JhiS4maaD9RRk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fdd502f921936105869eba53db6593fc2a424c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "UTPM is a package manager for local and remote Typst packages.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    crane.url = "github:ipetkov/crane";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  };
+
+  outputs = { self, ... }@inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+        };
+
+        craneLib = inputs.crane.mkLib pkgs;
+        src = ./.;
+
+        cargoArtifacts = craneLib.buildDepsOnly {
+          inherit src;
+          buildInputs = [ pkgs.openssl ];
+          nativeBuildInputs = [ pkgs.pkg-config  ];
+          OPENSSL_NO_VENDOR = 1;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.system}.default ];
+          packages = [
+            #lsp
+            pkgs.rust-analyzer
+          ];
+        };
+
+        packages = {
+          utpm = self.packages.${pkgs.system}.default;
+
+          default = craneLib.buildPackage {
+            buildInputs = [ pkgs.openssl ];
+            nativeBuildInputs = [ pkgs.pkg-config  ];
+            OPENSSL_NO_VENDOR = 1;
+            inherit cargoArtifacts src;
+            meta = {
+              homepage = "https://github.com/Thumuss/utpm";
+              licence = pkgs.stdenv.lib.licences.MIT;
+              description = "UTPM is a package manager for local and remote Typst packages.";
+              longDescription = "UTPM is a package manager for local and remote Typst packages. Quickly create and manage projects and templates on your system, and publish them directly to Typst Universe.";
+              mainProgram = "utpm";
+            };
+          };
+        };
+      }
+    );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      nodeName = lock.nodes.root.inputs.flake-compat;
+    in
+    fetchTarball {
+      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Added a nix package using the crane nix library for building rust packages.

nix without flake compatibility is done with the flake-compat library.

The readme is updated to inform users of this new possibility to use utpm.